### PR TITLE
Fix for settings not saving issues since 0.7.3

### DIFF
--- a/.github/workflows/get-version.js
+++ b/.github/workflows/get-version.js
@@ -1,0 +1,2 @@
+var fs = require('fs');
+console.log(JSON.parse(fs.readFileSync('module.json', 'utf8')).version);

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,43 @@
+name: vtta-tokenizer CI
+
+on:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - '**.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get Version                                   # Run the script that returns the version from `module.json`
+      shell: bash
+      id: get-version
+      run: echo "::set-output name=version::$(node ./.github/workflows/get-version.js)"
+    - run: zip -r ./vtta-tokenizer.zip module.json src css img lang LICENSE.md       # Add folders/files here
+    - name: Create Release                                # Create an additional release for this version
+      id: create_versioned_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: false # set to false if you do not want to allow updates on existing releases
+        name: Release ${{ steps.get-version.outputs.version }} # Use the version in the name
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json,./vtta-tokenizer.zip'    # don't forget to rename module zip thing
+        tag: ${{ steps.get-version.outputs.version }} # Use the version as the tag
+    - name: Create Release
+      id: create_latest_release
+      uses: ncipollo/release-action@v1
+      if: endsWith(github.ref, 'master') # Only update the latest release when pushing to the master branch
+      with:
+        allowUpdates: true
+        name: Latest
+        draft: false
+        prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json,./vtta-tokenizer.zip'  # don't forget to rename module zip thing
+        tag: latest

--- a/lang/es.json
+++ b/lang/es.json
@@ -1,0 +1,11 @@
+{
+  "vtta-tokenizer.default-frame-npc.name": "Marco por defecto para PNJ",
+  "vtta-tokenizer.default-frame-npc.hint": "Una imagen almacenada en el servidor Foundry que será utilizada como marco por defecto para npcs.",
+  "vtta-tokenizer.default-frame-pc.name": "Marco por defecto para Personajes",
+  "vtta-tokenizer.default-frame-pc.hint": "Una imagen almacenada en el servidor Foundry que será utilizada como marco por defecto para personajes.",
+  "vtta-tokenizer.image-upload-directory.name": "Directorio de subida de Avatares/Iconos",
+  "vtta-tokenizer.image-upload-directory.hint": "Especifica la localización en el servidor donde se subirán avatares e iconos, relativo al directorio Data de Foundry, p.ej. 'img/uploads' será '[Foundry]/Data/img/uploads'. Debes crear manualmente este directorio en el servidor.",
+  "vtta-tokenizer.token-size.name": "Tamaño de Icono",
+  "vtta-tokenizer.token-size.hint": "Especifica el tamaño de icono (ancho y alto). Se recomienza usar un valor por encima de 200.",
+  "vtta-tokenizer.requires-upload-permission": "Tokenizer necesita permiso para subir ficheros. Por favor, notifícaselo a tu Director de Juego."
+}

--- a/module.json
+++ b/module.json
@@ -16,6 +16,11 @@
       "lang": "de",
       "name": "Deutsch",
       "path": "lang/de.json"
+    },
+    {
+      "lang": "es",
+      "name": "Spanish",
+      "path": "lang/es.json"
     }
   ],
   "esmodules": ["./src/index.js"],

--- a/module.json
+++ b/module.json
@@ -1,11 +1,11 @@
 {
   "name": "vtta-tokenizer",
-  "title": "Virtual Tabletop Assets - Tokenizer",
+  "title": "Tokenizer - Temporary edition",
   "description": "Tiny yet capable in-game token editor, requires trusted user level for uploads",
-  "version": "2.2.1",
-  "minimumCoreVersion": "0.5.5",
-  "compatibleCoreVersion": "0.6.4",
-  "author": "Sebastian Will (vttassets@gmail.com)",
+  "version": "2.2.2",
+  "minimumCoreVersion": "0.7.5",
+  "compatibleCoreVersion": "0.7.5",
+  "author": "Sebastian Will (vttassets@gmail.com), Jack (jack@mrprimate.co.uk",
   "languages": [
     {
       "lang": "en",
@@ -26,7 +26,7 @@
   "esmodules": ["./src/index.js"],
   "styles": ["./css/module-settings.css", "./css/default.css", "./src/tokenizer/tokenizer.css"],
   "packs": [],
-  "url": "https://www.vttassets.com/asset/vtta-tokenizer",
-  "manifest": "https://www.vttassets.com/manifest/vtta-tokenizer/stable",
-  "download": ""
+  "url": "https://github.com/mrprimate/vtta-tokenizer/",
+  "manifest": "https://github.com/mrprimate/vtta-tokenizer/releases/download/latest/module.json",
+  "download": "https://github.com/mrprimate/vtta-tokenizer/releases/download/2.2.2/module.zip"
 }

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "name": "vtta-tokenizer",
-  "title": "Tokenizer - Temporary edition",
-  "description": "Tiny yet capable in-game token editor, requires trusted user level for uploads",
+  "title": "Tokenizer - v0.7.5 edition",
+  "description": "Tiny yet capable in-game token editor, requires trusted user level for uploads. This is a fork until vtta-tokenizer is fixed for v0.7.5.",
   "version": "2.2.2",
   "minimumCoreVersion": "0.7.5",
   "compatibleCoreVersion": "0.7.5",
@@ -28,5 +28,5 @@
   "packs": [],
   "url": "https://github.com/mrprimate/vtta-tokenizer/",
   "manifest": "https://github.com/mrprimate/vtta-tokenizer/releases/download/latest/module.json",
-  "download": "https://github.com/mrprimate/vtta-tokenizer/releases/download/2.2.2/module.zip"
+  "download": "https://github.com/mrprimate/vtta-tokenizer/releases/download/2.2.2/vtta-tokenizer.zip"
 }

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # VTTA Tokenizer
 
+This is a temporary fork to maintain compatibility with Foundry v0.7.5 till Sebastian returns from absence.
+
 ![](https://img.shields.io/badge/Foundry-v0.4.0-informational)
 
 Your players identify with their characters and a token represents their character - it should look awesome. Tokenizer is there to help.

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -11,7 +11,7 @@ export function init() {
   game.settings.register("vtta-tokenizer", "default-frame-pc", {
     name: "vtta-tokenizer.default-frame-pc.name",
     hint: "vtta-tokenizer.default-frame-pc.hint",
-    type: ImagePicker.Image,
+    type: ImagePicker.Img,
     default: "/modules/vtta-tokenizer/img/default-frame-pc.png",
     scope: "world",
     config: true,
@@ -20,7 +20,7 @@ export function init() {
   game.settings.register("vtta-tokenizer", "default-frame-npc", {
     name: "vtta-tokenizer.default-frame-npc.name",
     hint: "vtta-tokenizer.default-frame-npc.hint",
-    type: ImagePicker.Image,
+    type: ImagePicker.Img,
     //type: window.Azzu.SettingsTypes.FilePickerImage,
     default: "/modules/vtta-tokenizer/img/default-frame-npc.png",
     scope: "world",

--- a/src/libs/ImagePicker.js
+++ b/src/libs/ImagePicker.js
@@ -26,7 +26,7 @@ class ImagePicker extends FilePicker {
   }
 
   // returns the type "Directory" for rendering the SettingsConfig
-  static Image(val) {
+  static Img(val) {
     return val;
   }
 
@@ -69,7 +69,7 @@ class ImagePicker extends FilePicker {
   // Adds a FilePicker-Simulator-Button next to the input fields
   static processHtml(html) {
     $(html)
-      .find(`input[data-dtype="Image"]`)
+      .find(`input[data-dtype="Img"]`)
       .each(function () {
         if (!$(this).next().length) {
           let picker = new ImagePicker({


### PR DESCRIPTION
Since Foundry 0.7.3 the tokenizer has been causing an error in the Settings screen that would prevent any saves from happening. See https://github.com/VTTAssets/vtta-tokenizer/issues/22

As @BradKriss suggested in the issue, Image doesn't seem to be supported by the Settings anymore, but Img is supported. So 
 I tried switching the ImagePicker to define Img instead of Image and it fixed the issue.